### PR TITLE
Add coverage env for tox

### DIFF
--- a/egenix-mx-base-3.2.9/pytest.ini
+++ b/egenix-mx-base-3.2.9/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts=--tb native --cov-report term-missing --no-cov-on-fail --cov mx/DateTime
+addopts=--tb native

--- a/egenix-mx-base-3.2.9/tox.ini
+++ b/egenix-mx-base-3.2.9/tox.ini
@@ -5,4 +5,11 @@ envlist=py26,py27,py33,py34,py35
 deps=
     -r{toxinidir}/testrequirements.txt
 commands=
+    coverage erase
     py.test mx/DateTime/mxDateTime/tests {posargs}
+
+[testenv:coverage]
+basepython=python2.7
+commands=
+    py.test mx/DateTime/mxDateTime/tests {posargs} \
+        --cov mx/DateTime --no-cov-on-fail --cov-report=term-missing


### PR DESCRIPTION
Before, we ran coverage on every test run. Now, we only do it if explicitly requested on the command line (`-e coverage`).
